### PR TITLE
Correct "safey" -> "safety" typo

### DIFF
--- a/contracts/Entropy.sol
+++ b/contracts/Entropy.sol
@@ -77,7 +77,7 @@ contract Entropy is EntropyToken {
     Transfer(this, buyer, value);
   }
 
-  function changeSafeyLimit(uint _new_limit) onlyGuardians returns (bool success) {
+  function changeSafetyLimit(uint _new_limit) onlyGuardians returns (bool success) {
     // Limit can only be increased
     if(_new_limit < safety_limit) throw;
 

--- a/test/Entropy_token.js
+++ b/test/Entropy_token.js
@@ -91,7 +91,7 @@ contract('EntropyToken', (accounts) => {
     it("lets guardians change safety limit", (done) => {
       helpers.deployEntropyContract()
       .then((entropy) => {
-        entropy.changeSafeyLimit(500e18)
+        entropy.changeSafetyLimit(500e18)
         .then(() => {
           // Buy with 399 Eth worth of tokens
           entropy.buyTokens({ value: 399e18 })


### PR DESCRIPTION
Looked like a typo.